### PR TITLE
Add support for providing XCSF with a fixed seed

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,8 @@ set(XCSF_TESTS
     unit_tests.cpp
 )
 
+add_definitions(-DDSFMT_MEXP=19937)
+
 add_executable(tests ${XCSF_TESTS})
 target_link_libraries(tests xcs)
 

--- a/xcsf/pybind_wrapper.cpp
+++ b/xcsf/pybind_wrapper.cpp
@@ -1372,6 +1372,12 @@ class XCS
     {
         ea_param_set_pred_reset(&xcs, a);
     }
+
+    void
+    seed(const uint32_t seed)
+    {
+        rand_init_seed(seed);
+    }
 };
 
 PYBIND11_MODULE(xcsf, m)
@@ -1437,6 +1443,7 @@ PYBIND11_MODULE(xcsf, m)
         .def("end_step", &XCS::end_step)
         .def("decision", &XCS::decision)
         .def("update", &XCS::update)
+        .def("seed", &XCS::seed)
         .def_property("OMP_NUM_THREADS", &XCS::get_omp_num_threads,
                       &XCS::set_omp_num_threads)
         .def_property("POP_INIT", &XCS::get_pop_init, &XCS::set_pop_init)

--- a/xcsf/utils.c
+++ b/xcsf/utils.c
@@ -22,7 +22,6 @@
  */
 
 #include "utils.h"
-#include "../lib/dSFMT/dSFMT.h"
 #include <limits.h>
 #include <stdbool.h>
 #include <time.h>
@@ -39,6 +38,16 @@ rand_init(void)
     for (size_t i = 0; i < sizeof(now); ++i) {
         seed = (seed * (UCHAR_MAX + 2U)) + p[i];
     }
+    dsfmt_gv_init_gen_rand(seed);
+}
+
+/**
+ * @brief Initialises the pseudo-random number generator with a fixed seed.
+ * @param [in] a seed
+ */
+void
+rand_init_seed(const uint32_t seed)
+{
     dsfmt_gv_init_gen_rand(seed);
 }
 

--- a/xcsf/utils.h
+++ b/xcsf/utils.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "../lib/dSFMT/dSFMT.h"
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -38,6 +39,9 @@ rand_uniform_int(const int min, const int max);
 
 void
 rand_init(void);
+
+void
+rand_init_seed(const uint32_t seed);
 
 /**
  * @brief Returns a float clamped within the specified range.


### PR DESCRIPTION
Hi!

There are two main reasons for this PR:

- When submiting many XCSF runs to a cluster, the current implementation leads to most of them starting with the same random seed (due to the dependence on the current time in `rand_init`).
- Fixing the random seed is necessary for repeatability.

Note that I haven't used C for quite some time now and thus may have made mistakes; however, for me, the code of this PR seems to work–so far. :slightly_smiling_face: 