### PR TITLE
Make EA_SELECT_TYPE r/w symmetrical (Python lib)

### DIFF
--- a/xcsf/pybind_wrapper.cpp
+++ b/xcsf/pybind_wrapper.cpp
@@ -746,10 +746,10 @@ class XCS
         return xcs.P_EXPLORE;
     }
 
-    int
+    const char *
     get_ea_select_type(void)
     {
-        return xcs.ea->select_type;
+        return ea_type_as_string(xcs.ea->select_type);
     }
 
     double


### PR DESCRIPTION
Solves #15.

I think `EA_SELECT_TYPE` was the only asymmetric option.