### PR TITLE
add optional argument to predict/score functions to avoid covering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+Changes:
+*    Add an optional argument to the Python predict function that specifies the value to return for a sample if the match set is empty instead of invoking covering.
+
 ## Version 1.2.5 (Oct 3, 2022)
 
 Changes:

--- a/xcsf/clset.c
+++ b/xcsf/clset.c
@@ -17,7 +17,7 @@
  * @file clset.c
  * @author Richard Preen <rpreen@gmail.com>
  * @copyright The Authors.
- * @date 2015--2021.
+ * @date 2015--2023.
  * @brief Functions operating on sets of classifiers.
  */
 
@@ -322,12 +322,12 @@ clset_pset_enforce_limit(struct XCSF *xcsf)
  * @brief Constructs the match set - forward propagates conditions and actions.
  * @details Processes the matching conditions and actions for each classifier
  * in the population. If a classifier matches, it is added to the match set.
- * Covering is performed if any actions are unrepresented.
  * @param [in] xcsf The XCSF data structure.
  * @param [in] x The input state.
+ * @param [in] cover Whether to check action set coverage.
  */
 void
-clset_match(struct XCSF *xcsf, const double *x)
+clset_match(struct XCSF *xcsf, const double *x, const bool cover)
 {
 #ifdef PARALLEL_MATCH
     // prepare for parallel processing of matching conditions
@@ -361,7 +361,7 @@ clset_match(struct XCSF *xcsf, const double *x)
     }
 #endif
     // perform covering if all actions are not represented
-    if (xcsf->n_actions > 1 || xcsf->mset.size < 1) {
+    if (cover && (xcsf->n_actions > 1 || xcsf->mset.size < 1)) {
         clset_cover(xcsf, x);
     }
     // update statistics

--- a/xcsf/clset.h
+++ b/xcsf/clset.h
@@ -17,7 +17,7 @@
  * @file clset.h
  * @author Richard Preen <rpreen@gmail.com>
  * @copyright The Authors.
- * @date 2015--2020.
+ * @date 2015--2023.
  * @brief Functions operating on sets of classifiers.
  */
 
@@ -62,7 +62,7 @@ void
 clset_kill(const struct XCSF *xcsf, struct Set *set);
 
 void
-clset_match(struct XCSF *xcsf, const double *x);
+clset_match(struct XCSF *xcsf, const double *x, const bool cover);
 
 void
 clset_pset_enforce_limit(struct XCSF *xcsf);

--- a/xcsf/pybind_wrapper.cpp
+++ b/xcsf/pybind_wrapper.cpp
@@ -412,7 +412,7 @@ class XCS
             err << "2-D arrays are required. Perhaps reshape your data.";
             throw std::invalid_argument(err.str());
         }
-        const double *input = (double *) buf_x.ptr;
+        const double *input = reinterpret_cast<double *>(buf_x.ptr);
         double *output =
             (double *) malloc(sizeof(double) * n_samples * xcs.pa_size);
         xcs_supervised_predict(&xcs, input, output, n_samples, cover);
@@ -438,7 +438,8 @@ class XCS
                   << std::endl;
             throw std::invalid_argument(error.str());
         }
-        return get_predictions(X, (double *) buf_c.ptr);
+        const double *cov = reinterpret_cast<double *>(buf_c.ptr);
+        return get_predictions(X, cov);
     }
 
     /**

--- a/xcsf/pybind_wrapper.cpp
+++ b/xcsf/pybind_wrapper.cpp
@@ -432,11 +432,10 @@ class XCS
     {
         const py::buffer_info buf_c = cover.request();
         if (buf_c.shape[0] != xcs.y_dim) {
-            std::ostringstream error;
-            error << "predict(): cover dim (" << buf_c.shape[0]
-                  << ") is not equal to y_dim (" << xcs.y_dim << ")"
-                  << std::endl;
-            throw std::invalid_argument(error.str());
+            std::ostringstream err;
+            err << "predict(): cover dim (" << buf_c.shape[0]
+                << ") is not equal to y_dim (" << xcs.y_dim << ")" << std::endl;
+            throw std::invalid_argument(err.str());
         }
         const double *cov = reinterpret_cast<double *>(buf_c.ptr);
         return get_predictions(X, cov);

--- a/xcsf/pybind_wrapper.cpp
+++ b/xcsf/pybind_wrapper.cpp
@@ -454,18 +454,6 @@ class XCS
     }
 
     /**
-     * @brief Returns the error over one sequential pass of the provided data.
-     * @param [in] X The input values to use for scoring.
-     * @param [in] Y The true output values to use for scoring.
-     * @return The average XCSF error using the loss function.
-     */
-    double
-    score(const py::array_t<double> X, const py::array_t<double> Y)
-    {
-        return score(X, Y, 0);
-    }
-
-    /**
      * @brief Returns the error using N random samples from the provided data.
      * @param [in] X The input values to use for scoring.
      * @param [in] Y The true output values to use for scoring.
@@ -1264,12 +1252,6 @@ PYBIND11_MODULE(xcsf, m)
                         const py::array_t<double>, const py::array_t<double>,
                         const bool) = &XCS::fit;
 
-    double (XCS::*score1)(const py::array_t<double> test_X,
-                          const py::array_t<double> test_Y) = &XCS::score;
-    double (XCS::*score2)(const py::array_t<double> test_X,
-                          const py::array_t<double> test_Y, const int N) =
-        &XCS::score;
-
     py::array_t<double> (XCS::*predict1)(const py::array_t<double> test_X) =
         &XCS::predict;
     py::array_t<double> (XCS::*predict2)(const py::array_t<double> test_X,
@@ -1332,16 +1314,11 @@ PYBIND11_MODULE(xcsf, m)
              "x_dim). y_test shape must be: (n_samples, y_dim).",
              py::arg("X_train"), py::arg("y_train"), py::arg("X_test"),
              py::arg("y_test"), py::arg("shuffle"))
-        .def("score", score1,
-             "Returns the error over one sequential pass of the provided data. "
-             "X_val shape must be: (n_samples, x_dim). y_val shape must be: "
-             "(n_samples, y_dim).",
-             py::arg("X_val"), py::arg("y_val"))
-        .def("score", score2,
+        .def("score", &XCS::score,
              "Returns the error using at most N random samples from the "
              "provided data. X_val shape must be: (n_samples, x_dim). y_val "
              "shape must be: (n_samples, y_dim).",
-             py::arg("X_val"), py::arg("y_val"), py::arg("N"))
+             py::arg("X_val"), py::arg("y_val"), py::arg("N") = 0)
         .def("error", error1,
              "Returns a moving average of the system error, updated with step "
              "size BETA.")

--- a/xcsf/pybind_wrapper.cpp
+++ b/xcsf/pybind_wrapper.cpp
@@ -406,11 +406,11 @@ class XCS
         const py::buffer_info buf_x = X.request();
         const int n_samples = buf_x.shape[0];
         if (buf_x.shape[1] != xcs.x_dim) {
-            std::ostringstream error;
-            error << "predict(): x_dim (" << buf_x.shape[1]
-                  << ") is not equal to: " << xcs.x_dim << std::endl;
-            error << "2-D arrays are required. Perhaps reshape your data.";
-            throw std::invalid_argument(error.str());
+            std::ostringstream err;
+            err << "predict(): x_dim (" << buf_x.shape[1]
+                << ") is not equal to: " << xcs.x_dim << std::endl;
+            err << "2-D arrays are required. Perhaps reshape your data.";
+            throw std::invalid_argument(err.str());
         }
         const double *input = (double *) buf_x.ptr;
         double *output =

--- a/xcsf/xcs_rl.c
+++ b/xcsf/xcs_rl.c
@@ -17,7 +17,7 @@
  * @file xcs_rl.c
  * @author Richard Preen <rpreen@gmail.com>
  * @copyright The Authors.
- * @date 2015--2020.
+ * @date 2015--2023.
  * @brief Reinforcement learning functions.
  * @details A trial consists of one or more steps.
  */
@@ -106,7 +106,7 @@ xcs_rl_fit(struct XCSF *xcsf, const double *state, const int action,
 {
     xcs_rl_init_trial(xcsf);
     xcs_rl_init_step(xcsf);
-    clset_match(xcsf, state);
+    clset_match(xcsf, state, true);
     pa_build(xcsf, state);
     const double prediction = pa_val(xcsf, action);
     const double error = (xcsf->loss_ptr)(xcsf, &prediction, &reward);
@@ -249,7 +249,7 @@ xcs_rl_error(struct XCSF *xcsf, const int action, const double reward,
 int
 xcs_rl_decision(struct XCSF *xcsf, const double *state)
 {
-    clset_match(xcsf, state);
+    clset_match(xcsf, state, true);
     pa_build(xcsf, state);
     if (xcsf->explore && rand_uniform(0, 1) < xcsf->P_EXPLORE) {
         return pa_rand_action(xcsf);

--- a/xcsf/xcs_supervised.h
+++ b/xcsf/xcs_supervised.h
@@ -17,7 +17,7 @@
  * @file xcs_supervised.h
  * @author Richard Preen <rpreen@gmail.com>
  * @copyright The Authors.
- * @date 2015--2020.
+ * @date 2015--2023.
  * @brief Supervised regression learning functions.
  */
 
@@ -30,12 +30,13 @@ xcs_supervised_fit(struct XCSF *xcsf, const struct Input *train_data,
                    const struct Input *test_data, const bool shuffle);
 
 double
-xcs_supervised_score(struct XCSF *xcsf, const struct Input *data);
+xcs_supervised_score(struct XCSF *xcsf, const struct Input *data,
+                     const double *cover);
 
 double
-xcs_supervised_score_n(struct XCSF *xcsf, const struct Input *data,
-                       const int N);
+xcs_supervised_score_n(struct XCSF *xcsf, const struct Input *data, const int N,
+                       const double *cover);
 
 void
 xcs_supervised_predict(struct XCSF *xcsf, const double *x, double *pred,
-                       const int n_samples);
+                       const int n_samples, const double *cover);


### PR DESCRIPTION
Python `xcs.predict()` now takes an optional argument that specifies the value to return for a sample that results in an empty match set instead of invoking covering.

Example for `y_dim=1`

```python
pred = xcs.predict(X_test, cover=[0.5])
```

------

Same for `xcs.score()`

Example for `y_dim=2`

```python
error = xcs.score(X_val, cover=[0.1, 0.5])
```