### PR TITLE
add RANDOM_STATE parameter; remove seed()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Changes:
 *   Accept 1-D flattened Python inputs in fit/score/predict ([#81](https://github.com/rpreen/xcsf/pull/81))
 *   Fix setting max trials via JSON ([#83](https://github.com/rpreen/xcsf/pull/83))
+*   Remove Python `seed()` and add `RANDOM_STATE` parameter for setting seed ([#86](https://github.com/rpreen/xcsf/pull/86))
 
 ## Version 1.2.9 (Jul 9, 2023)
 

--- a/cfg/default.json
+++ b/cfg/default.json
@@ -1,5 +1,6 @@
 {
     "omp_num_threads": 8,
+    "random_state": 0,
     "pop_init": true,
     "max_trials": 100000,
     "perf_trials": 1000,

--- a/xcsf/main.c
+++ b/xcsf/main.c
@@ -40,7 +40,6 @@ main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
     struct XCSF *xcsf = malloc(sizeof(struct XCSF));
-    rand_init();
     env_init(xcsf, argv); // initialise environment and default parameters
     if (argc > 3) { // load parameter config
         config_read(xcsf, argv[3]);

--- a/xcsf/param.c
+++ b/xcsf/param.c
@@ -56,6 +56,7 @@ param_init(struct XCSF *xcsf, const int x_dim, const int y_dim,
     param_set_x_dim(xcsf, x_dim);
     param_set_y_dim(xcsf, y_dim);
     param_set_omp_num_threads(xcsf, 8);
+    param_set_random_state(xcsf, 0);
     param_set_pop_init(xcsf, true);
     param_set_max_trials(xcsf, 100000);
     param_set_perf_trials(xcsf, 1000);
@@ -112,6 +113,7 @@ param_json_export(const struct XCSF *xcsf)
     cJSON_AddNumberToObject(json, "y_dim", xcsf->y_dim);
     cJSON_AddNumberToObject(json, "n_actions", xcsf->n_actions);
     cJSON_AddNumberToObject(json, "omp_num_threads", xcsf->OMP_NUM_THREADS);
+    cJSON_AddNumberToObject(json, "random_state", xcsf->RANDOM_STATE);
     cJSON_AddBoolToObject(json, "pop_init", xcsf->POP_INIT);
     cJSON_AddNumberToObject(json, "max_trials", xcsf->MAX_TRIALS);
     cJSON_AddNumberToObject(json, "perf_trials", xcsf->PERF_TRIALS);
@@ -188,6 +190,9 @@ param_json_import_general(struct XCSF *xcsf, const cJSON *json)
     } else if (strncmp(json->string, "omp_num_threads\0", 16) == 0 &&
                cJSON_IsNumber(json)) {
         catch_error(param_set_omp_num_threads(xcsf, json->valueint));
+    } else if (strncmp(json->string, "random_state\0", 13) == 0 &&
+               cJSON_IsNumber(json)) {
+        catch_error(param_set_random_state(xcsf, json->valueint));
     } else if (strncmp(json->string, "pop_size\0", 9) == 0 &&
                cJSON_IsNumber(json)) {
         catch_error(param_set_pop_size(xcsf, json->valueint));
@@ -462,6 +467,7 @@ param_save(const struct XCSF *xcsf, FILE *fp)
     s += fwrite(&xcsf->y_dim, sizeof(int), 1, fp);
     s += fwrite(&xcsf->n_actions, sizeof(int), 1, fp);
     s += fwrite(&xcsf->OMP_NUM_THREADS, sizeof(int), 1, fp);
+    s += fwrite(&xcsf->RANDOM_STATE, sizeof(int), 1, fp);
     s += fwrite(&xcsf->POP_INIT, sizeof(bool), 1, fp);
     s += fwrite(&xcsf->MAX_TRIALS, sizeof(int), 1, fp);
     s += fwrite(&xcsf->PERF_TRIALS, sizeof(int), 1, fp);
@@ -515,6 +521,7 @@ param_load(struct XCSF *xcsf, FILE *fp)
         exit(EXIT_FAILURE);
     }
     s += fread(&xcsf->OMP_NUM_THREADS, sizeof(int), 1, fp);
+    s += fread(&xcsf->RANDOM_STATE, sizeof(int), 1, fp);
     s += fread(&xcsf->POP_INIT, sizeof(bool), 1, fp);
     s += fread(&xcsf->MAX_TRIALS, sizeof(int), 1, fp);
     s += fread(&xcsf->PERF_TRIALS, sizeof(int), 1, fp);
@@ -563,6 +570,18 @@ param_set_omp_num_threads(struct XCSF *xcsf, const int a)
 #ifdef PARALLEL
     omp_set_num_threads(xcsf->OMP_NUM_THREADS);
 #endif
+    return NULL;
+}
+
+const char *
+param_set_random_state(struct XCSF *xcsf, const int a)
+{
+    xcsf->RANDOM_STATE = a;
+    if (a > 0) {
+        rand_init_seed(a);
+    } else {
+        rand_init();
+    }
     return NULL;
 }
 

--- a/xcsf/param.h
+++ b/xcsf/param.h
@@ -58,6 +58,9 @@ const char *
 param_set_omp_num_threads(struct XCSF *xcsf, const int a);
 
 const char *
+param_set_random_state(struct XCSF *xcsf, const int a);
+
+const char *
 param_set_pop_init(struct XCSF *xcsf, const bool a);
 
 const char *

--- a/xcsf/pybind_wrapper.cpp
+++ b/xcsf/pybind_wrapper.cpp
@@ -612,6 +612,12 @@ class XCS
         return xcs.OMP_NUM_THREADS;
     }
 
+    int
+    get_random_state(void)
+    {
+        return xcs.RANDOM_STATE;
+    }
+
     bool
     get_pop_init(void)
     {
@@ -1067,6 +1073,12 @@ class XCS
     }
 
     void
+    set_random_state(const int a)
+    {
+        catch_error(param_set_random_state(&xcs, a));
+    }
+
+    void
     set_pop_init(const bool a)
     {
         catch_error(param_set_pop_init(&xcs, a));
@@ -1262,12 +1274,6 @@ class XCS
         catch_error(ea_param_set_pred_reset(&xcs, a));
     }
 
-    void
-    seed(const uint32_t seed)
-    {
-        rand_init_seed(seed);
-    }
-
     /* JSON */
 
     /**
@@ -1364,7 +1370,6 @@ PYBIND11_MODULE(xcsf, m)
     m.doc() = "XCSF learning classifier: rule-based online evolutionary "
               "machine learning.\nFor details on how to use this module see: "
               "https://github.com/rpreen/xcsf/wiki/Python-Library-Usage";
-    rand_init();
 
     double (XCS::*fit1)(const py::array_t<double>, const int, const double) =
         &XCS::fit;
@@ -1503,10 +1508,10 @@ PYBIND11_MODULE(xcsf, m)
         .def("update", &XCS::update,
              "Creates the action set using the previously selected action.",
              py::arg("reward"), py::arg("done"))
-        .def("seed", &XCS::seed, "Sets the random number seed.",
-             py::arg("seed"))
         .def_property("OMP_NUM_THREADS", &XCS::get_omp_num_threads,
                       &XCS::set_omp_num_threads, "Number of CPU cores to use.")
+        .def_property("RANDOM_STATE", &XCS::get_random_state,
+                      &XCS::set_random_state, "Random seed; 0 = None")
         .def_property("POP_INIT", &XCS::get_pop_init, &XCS::set_pop_init,
                       "Whether to seed the population with random rules.")
         .def_property("MAX_TRIALS", &XCS::get_max_trials, &XCS::set_max_trials,

--- a/xcsf/xcsf.h
+++ b/xcsf/xcsf.h
@@ -131,6 +131,7 @@ struct XCSF {
     int THETA_DEL; //!< Min experience before fitness used during deletion
     int M_PROBATION; //!< Trials since creation a cl must match at least 1 input
     int THETA_SUB; //!< Minimum experience of a classifier to become a subsumer
+    int RANDOM_STATE; //!< Random number seed
     bool POP_INIT; //!< Pop initially empty or filled with random conditions
     bool SET_SUBSUMPTION; //!< Whether to perform match set subsumption
     bool STATEFUL; //!< Whether classifiers should retain state across trials


### PR DESCRIPTION
Resolves #85 

* Removes the Python function used for setting the random number: `def seed(value: int) -> None`
* Adds the parameter `RANDOM_STATE` to XCSF - set via the property in Python
* Adds `"random_state": 0` to `default.json` for setting the stand-alone executable random seed
* Setting `RANDOM_STATE=0` uses the current time

Note: this will break backward compatibility with serialization.