### PR TITLE
Add check for array contiguity

### DIFF
--- a/xcsf/pybind_wrapper.cpp
+++ b/xcsf/pybind_wrapper.cpp
@@ -340,6 +340,14 @@ class XCS
         // access input
         const py::buffer_info buf_x = X.request();
         const py::buffer_info buf_y = Y.request();
+        // check array contiguity
+        // https://github.com/pybind/pybind11/discussions/4211#discussioncomment-3905115
+        const int C_CONTIGUOUS =
+            py::detail::npy_api::constants::NPY_ARRAY_C_CONTIGUOUS_;
+        if (!(C_CONTIGUOUS == (X.flags() & C_CONTIGUOUS)) ||
+            !(C_CONTIGUOUS == (Y.flags() & C_CONTIGUOUS))) {
+            throw std::invalid_argument("X and Y must be C-contiguous");
+        }
         // check input shape
         if (buf_x.ndim < 1 || buf_x.ndim > 2) {
             throw std::invalid_argument("X must be 1 or 2-D array");
@@ -584,6 +592,13 @@ class XCS
     predict(const py::array_t<double> X, const py::object &cover)
     {
         const py::buffer_info buf_x = X.request();
+        // check array contiguity
+        // https://github.com/pybind/pybind11/discussions/4211#discussioncomment-3905115
+        const int C_CONTIGUOUS =
+            py::detail::npy_api::constants::NPY_ARRAY_C_CONTIGUOUS_;
+        if (!(C_CONTIGUOUS == (X.flags() & C_CONTIGUOUS))) {
+            throw std::invalid_argument("X must be C-contiguous");
+        }
         if (buf_x.ndim < 1 || buf_x.ndim > 2) {
             throw std::invalid_argument("predict(): X must be 1 or 2-D array");
         }


### PR DESCRIPTION
Fixes #198 for now by throwing an error.

For me, this works:
```
>>> import xcsf
>>> import numpy as np
>>> xcsf.XCS(x_dim=2, max_trials=10).fit(np.array([[1.1, 1.3], [1.2, 2.2]], order='F'), np.array([0.0, 1.0], order='F'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: X and Y must be C-contiguous
>>> xcsf.XCS(x_dim=2, max_trials=10).fit(np.array([[1.1, 1.3], [1.2, 2.2]]), np.array([0.0, 1.0], order='F'))
2025-07-16T16:04:29.780 trials=10 train=0.52924 pset=2000.0 mset=105.6 mfrac=0.00
>>> 
```