### PR TITLE
feat: use proper tempfiles in {de,}serialize

### DIFF
--- a/xcsf/pybind_wrapper.cpp
+++ b/xcsf/pybind_wrapper.cpp
@@ -649,8 +649,15 @@ class XCS
     py::bytes
     serialize() const
     {
-        // Write XCSF to a temporary binary file
-        const char *filename = "_tmp_pickle.bin";
+        // Create a unique temporary file in /tmp. The file name is made unique
+        // in place by mkstemp.
+        char filename[] = "/tmp/xcsf_pickle_XXXXXX";
+        int fd = mkstemp(filename);
+        if (fd == -1) {
+            throw std::runtime_error("Failed to create temporary file in serialize");
+        }
+        close(fd);
+
         xcsf_save(&xcs, filename);
         // Read the binary file into bytes
         std::ifstream file(filename, std::ios::binary);
@@ -673,8 +680,16 @@ class XCS
     static XCS
     deserialize(const py::bytes &state)
     {
-        // Write the XCSF bytes to a temporary binary file
-        const char *filename = "_tmp_pickle.bin";
+        // Create a unique temporary file in /tmp. The file name is made unique
+        // in place by mkstemp.
+        char filename[] = "/tmp/xcsf_pickle_XXXXXX";
+        int fd = mkstemp(filename);
+        if (fd == -1) {
+            throw std::runtime_error("Failed to create temporary file in deserialize");
+        }
+        close(fd);
+
+        // Write the XCSF bytes to the temporary file.
         std::ofstream file(filename, std::ios::binary);
         file.write(state.cast<std::string>().c_str(),
                    state.cast<std::string>().size());

--- a/xcsf/pybind_wrapper.cpp
+++ b/xcsf/pybind_wrapper.cpp
@@ -654,7 +654,8 @@ class XCS
         char filename[] = "/tmp/xcsf_pickle_XXXXXX";
         int fd = mkstemp(filename);
         if (fd == -1) {
-            throw std::runtime_error("Failed to create temporary file in serialize");
+            throw std::runtime_error(
+                "Failed to create temporary file in serialize");
         }
         close(fd);
 
@@ -685,7 +686,8 @@ class XCS
         char filename[] = "/tmp/xcsf_pickle_XXXXXX";
         int fd = mkstemp(filename);
         if (fd == -1) {
-            throw std::runtime_error("Failed to create temporary file in deserialize");
+            throw std::runtime_error(
+                "Failed to create temporary file in deserialize");
         }
         close(fd);
 


### PR DESCRIPTION
Serialization is broken due to always using the same fixed file name (relative to the current working directory) for the temporary pickle files. This is a problem in setups where multiple instances of XCSF run in parallel (e.g. on Slurm clusters).

This PR simply replaces the hardcoded file name with `mkstemp`.